### PR TITLE
embrace author starting from given name

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -60,7 +60,8 @@ bibtex_writer <- function(bibtex_data, file_name) {
 
         # author field
         author <- bibtex_data[["book"]][[iterator]]$author
-        line_author <- sprintf("author = {{%s}},", author)
+        line_author <- gsub("([^a-z]*)([A-Z])([^.].*)",
+                            "author = {\\1{\\2\\3}},", author)
 
         # title field
         title <- bibtex_data[["book"]][[iterator]]$title


### PR DESCRIPTION
This implements the fix discussed in issue #4, to embrace the author list starting from the first full word - usually the first given name. This should mean that references are ordered by first full word rather than first author initial.